### PR TITLE
Make bld.sh work without pushd/popd

### DIFF
--- a/build/bld.sh
+++ b/build/bld.sh
@@ -1,8 +1,8 @@
 chmod +x ../glpk/glpk-5.0/configure
 rm -rf xout_linux/
 mkdir xout_linux
-pushd xout_linux
+cd xout_linux/
 ../../glpk/glpk-5.0/configure
 make
 ls -la src/.libs/libglpk.so*
-popd
+cd ..

--- a/pipelines/build_linux.yml
+++ b/pipelines/build_linux.yml
@@ -21,6 +21,10 @@ jobs:
     clean: true
     lfs: true
 
+  - script: chmod +x ./bld.sh
+    displayName: Prep bld.sh
+    workingDirectory: $(Build.SourcesDirectory)/build
+
   - script: ./bld.sh
     displayName: Build Glpk
     workingDirectory: $(Build.SourcesDirectory)/build


### PR DESCRIPTION
Need a couple more details for the linux pipeline to run: `chmod +x ./bld.sh` and can't use pushd/popd.