### PR TITLE
Fix package build error - can't have both license file and license expr

### DIFF
--- a/package/Glpk.Native.csproj
+++ b/package/Glpk.Native.csproj
@@ -21,7 +21,7 @@
     <Authors>Andrew Makhorin, Free Software Foundation Inc., Microsoft Corporation</Authors>
     <Copyright>© Free Software Foundation</Copyright>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+    <!-- <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression> -->
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
   </PropertyGroup>
 


### PR DESCRIPTION
Building the package fails because you can't specify both a license file and license expression. This fixes that issue.