### PR TITLE
Add cgmanifest.json for component governance scan

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,0 +1,14 @@
+{
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "other",
+        "other": {
+          "name": "GLPK",
+          "version": "5.0",
+          "downloadUrl": "https://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adding cgmanifest.json file with the GLPK 5.0 source information for Component Governance scan.